### PR TITLE
support for selectedIndex

### DIFF
--- a/flickity.vue
+++ b/flickity.vue
@@ -40,6 +40,10 @@ export default {
             this.flickity.select(index, isWrapped, isInstant);
         },
 
+        selectedIndex () {
+            return this.flickity.selectedIndex
+        },
+
         selectCell (value, isWrapped, isInstant) {
             this.flickity.selectCell( value, isWrapped, isInstant );
         },


### PR DESCRIPTION
I've noticed there's no method to get `selectedIndex` out of Flickity when you're inside events, so I've added it.