### PR TITLE
Changed "beforeDestroy" to "afterDestroy"

### DIFF
--- a/flickity.vue
+++ b/flickity.vue
@@ -22,7 +22,7 @@ export default {
       this.init();
     },
 
-    beforeDestroy () {
+    afterDestroy () {
         this.flickity.destroy();
         this.flickity = null;
     },

--- a/flickity.vue
+++ b/flickity.vue
@@ -22,7 +22,7 @@ export default {
       this.init();
     },
 
-    afterDestroy () {
+    destroy () {
         this.flickity.destroy();
         this.flickity = null;
     },


### PR DESCRIPTION
Destroying flickity instance on component's afterDestroy lifecycle event.  Prevents widget from visibly losing styles when component exists in a router-view with transition effects.