### PR TITLE
Emit init event

### DIFF
--- a/flickity.vue
+++ b/flickity.vue
@@ -30,6 +30,7 @@ export default {
     methods: {
         init() {
             this.flickity = new Flickity(this.$el, this.options);
+            this.$emit('init', this.flickity);
         },
 
         next (isWrapped, isInstant) {


### PR DESCRIPTION
Emit init event to allow easy binding to flickity events from parent component